### PR TITLE
Adicionando opção de links para o cabeçalho

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Alterações
   [idgserpro]
 * Ajusta dicionário tamanhos de tile Nitf para português. (closes `#123`_).
   [dbarbato]
-
+* Inclue opção de link para o título do cabeçalho de acordo com a recomendação 3.5 do eMAG. 
+  [caduviera]
 
 1.0.6 (2015-02-06)
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,13 +3,14 @@ Alterações
 
 1.0.7 (unreleased)
 ^^^^^^^^^^^^^^^^^^
+* Inclue opção de link para o título do cabeçalho de acordo com a recomendação 3.5 do eMAG. 
+  [caduviera]
 * Ajusta internacionalização nas strings de templates com traduções faltantes  
   no domínio brasil.gov.tiles. (closes `#26`_).
   [idgserpro]
 * Ajusta dicionário tamanhos de tile Nitf para português. (closes `#123`_).
   [dbarbato]
-* Inclue opção de link para o título do cabeçalho de acordo com a recomendação 3.5 do eMAG. 
-  [caduviera]
+
 
 1.0.6 (2015-02-06)
 ^^^^^^^^^^^^^^^^^^

--- a/src/brasil/gov/tiles/locales/brasil.gov.tiles.pot
+++ b/src/brasil/gov/tiles/locales/brasil.gov.tiles.pot
@@ -452,3 +452,6 @@ msgstr ""
 msgid "unmute"
 msgstr ""
 
+#: ./tiles/header.py:18
+msgid "Link title"
+msgstr ""

--- a/src/brasil/gov/tiles/locales/pt_BR/LC_MESSAGES/brasil.gov.tiles.po
+++ b/src/brasil/gov/tiles/locales/pt_BR/LC_MESSAGES/brasil.gov.tiles.po
@@ -452,3 +452,7 @@ msgstr "Título do tile List"
 msgid "unmute"
 msgstr "Ativar som"
 
+#: ./tiles/header.py:18
+msgid "Link title"
+msgstr "Url para o título"
+

--- a/src/brasil/gov/tiles/tests/test_header.py
+++ b/src/brasil/gov/tiles/tests/test_header.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from brasil.gov.tiles.testing import BaseIntegrationTestCase
+from brasil.gov.tiles.tiles.header import HeaderTile
+from collective.cover.controlpanel import ICoverSettings
+from collective.cover.tiles.base import IPersistentCoverTile
+from collective.cover.tests.base import TestTileMixin
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from zope.interface.verify import verifyClass
+from zope.interface.verify import verifyObject
+
+import unittest
+
+class HeaderTileTestCase(BaseIntegrationTestCase):
+
+    def setUp(self):
+        super(HeaderTileTestCase, self).setUp()
+        self.tile = self.portal.restrictedTraverse(
+            '@@%s/%s' % ('standaloneheader', 'test-tile'))
+
+
+    def test_interface(self):
+        self.assertTrue(IPersistentCoverTile.implementedBy(HeaderTile))
+        self.assertTrue(verifyClass(IPersistentCoverTile, HeaderTile))
+
+        tile = HeaderTile(None, None)
+        self.assertTrue(IPersistentCoverTile.providedBy(tile))
+        self.assertTrue(verifyObject(IPersistentCoverTile, tile))
+
+
+    def test_default_configuration(self):
+        self.assertTrue(self.tile.is_configurable)
+        self.assertTrue(self.tile.is_droppable)
+        self.assertTrue(self.tile.is_editable)
+
+    def test_accepted_content_types(self):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ICoverSettings)
+        self.assertEqual(
+            self.tile.accepted_ct(),
+            settings.searchable_content_types
+        )
+
+    def test_populate_with_object(self):
+
+        obj = self.portal['my-news-item']
+        self.tile.populate_with_object(obj)
+        rendered = self.tile()
+
+        # Checando por link no título
+        self.assertIn(
+            '<h2 class="outstanding-title"><a href="http://nohost/plone/my-news-'+
+            'item">Test news item</a></h2>',
+            rendered
+        )
+        self.assertIn(
+            '<a class="outstanding-link" href="http://nohost/plone/my-news-item"',
+            rendered
+        )

--- a/src/brasil/gov/tiles/tests/test_header.py
+++ b/src/brasil/gov/tiles/tests/test_header.py
@@ -3,13 +3,11 @@ from brasil.gov.tiles.testing import BaseIntegrationTestCase
 from brasil.gov.tiles.tiles.header import HeaderTile
 from collective.cover.controlpanel import ICoverSettings
 from collective.cover.tiles.base import IPersistentCoverTile
-from collective.cover.tests.base import TestTileMixin
 from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 from zope.interface.verify import verifyClass
 from zope.interface.verify import verifyObject
 
-import unittest
 
 class HeaderTileTestCase(BaseIntegrationTestCase):
 
@@ -18,15 +16,12 @@ class HeaderTileTestCase(BaseIntegrationTestCase):
         self.tile = self.portal.restrictedTraverse(
             '@@%s/%s' % ('standaloneheader', 'test-tile'))
 
-
     def test_interface(self):
         self.assertTrue(IPersistentCoverTile.implementedBy(HeaderTile))
         self.assertTrue(verifyClass(IPersistentCoverTile, HeaderTile))
-
         tile = HeaderTile(None, None)
         self.assertTrue(IPersistentCoverTile.providedBy(tile))
         self.assertTrue(verifyObject(IPersistentCoverTile, tile))
-
 
     def test_default_configuration(self):
         self.assertTrue(self.tile.is_configurable)
@@ -49,11 +44,12 @@ class HeaderTileTestCase(BaseIntegrationTestCase):
 
         # Checando por link no título
         self.assertIn(
-            '<h2 class="outstanding-title"><a href="http://nohost/plone/my-news-'+
-            'item">Test news item</a></h2>',
+            '<h2 class="outstanding-title"><a href="http://nohost/plone/my-' +
+            'news-item">Test news item</a></h2>',
             rendered
         )
         self.assertIn(
-            '<a class="outstanding-link" href="http://nohost/plone/my-news-item"',
+            '<a class="outstanding-link" href="http://nohost/plone/my-news' +
+            '-item"',
             rendered
         )

--- a/src/brasil/gov/tiles/tiles/header.py
+++ b/src/brasil/gov/tiles/tiles/header.py
@@ -16,6 +16,12 @@ class IHeaderTile(IPersistentCoverTile):
         required=False,
     )
 
+    link_title = schema.TextLine(
+        title=_(u'Link title'),
+        default=None,
+        required=False,
+    )
+
     link_text = schema.TextLine(
         title=_(u'Link text'),
         required=False,
@@ -46,10 +52,12 @@ class HeaderTile(PersistentCoverTile):
 
         title = obj.Title()
         url = obj.absolute_url()
+        link_title = obj.Link_title()
         link_text = title
         data_mgr = ITileDataManager(self)
         uuid = IUUID(obj)
         data_mgr.set({'title': title,
+                      'link_title': link_title,
                       'link_url': url,
                       'link_text': link_text,
                       'uuid': uuid

--- a/src/brasil/gov/tiles/tiles/header.py
+++ b/src/brasil/gov/tiles/tiles/header.py
@@ -52,7 +52,7 @@ class HeaderTile(PersistentCoverTile):
 
         title = obj.Title()
         url = obj.absolute_url()
-        link_title = obj.Link_title()
+        link_title = url
         link_text = title
         data_mgr = ITileDataManager(self)
         uuid = IUUID(obj)

--- a/src/brasil/gov/tiles/tiles/header.py
+++ b/src/brasil/gov/tiles/tiles/header.py
@@ -18,7 +18,7 @@ class IHeaderTile(IPersistentCoverTile):
 
     link_title = schema.TextLine(
         title=_(u'Link title'),
-        default=None,
+        default='',
         required=False,
     )
 

--- a/src/brasil/gov/tiles/tiles/header.py
+++ b/src/brasil/gov/tiles/tiles/header.py
@@ -18,7 +18,7 @@ class IHeaderTile(IPersistentCoverTile):
 
     link_title = schema.TextLine(
         title=_(u'Link title'),
-        default='',
+        default=(u''),
         required=False,
     )
 

--- a/src/brasil/gov/tiles/tiles/templates/header.pt
+++ b/src/brasil/gov/tiles/tiles/templates/header.pt
@@ -18,10 +18,10 @@
         <tal:title define="htmltag python:field.get('htmltag', 'h1')"
                  condition="python:field['id'] == 'title'">
 
-            <h1 class="outstanding-title" tal:content="view/data/title" tal:condition="python:htmltag == 'h1'"></h1>
-            <h2 class="outstanding-title" tal:content="view/data/title" tal:condition="python:htmltag == 'h2'"></h2>
-            <h3 class="outstanding-title" tal:content="view/data/title" tal:condition="python:htmltag == 'h3'"></h3>
-            <h4 class="outstanding-title" tal:content="view/data/title" tal:condition="python:htmltag == 'h4'"></h4>
+            <h1 class="outstanding-title" tal:condition="python:htmltag == 'h1'"><a tal:omit-tag="not:view/data/link_title" href="" tal:attributes="href view/data/link_title" tal:content="view/data/title"/></h1>
+            <h2 class="outstanding-title" tal:condition="python:htmltag == 'h2'"><a tal:omit-tag="not:view/data/link_title" href="" tal:attributes="href view/data/link_title" tal:content="view/data/title"/></h2>
+            <h3 class="outstanding-title" tal:condition="python:htmltag == 'h3'"><a tal:omit-tag="not:view/data/link_title" href="" tal:attributes="href view/data/link_title" tal:content="view/data/title"/></h3>
+            <h4 class="outstanding-title" tal:condition="python:htmltag == 'h4'"><a tal:omit-tag="not:view/data/link_title" href="" tal:attributes="href view/data/link_title" tal:content="view/data/title"/></h4>
 
         </tal:title>
     </tal:fields>


### PR DESCRIPTION
Para dar outra opção para criar o link no próprio texto do cabeçalho e assim não precisar colocar o link em um texto abaixo ou usar o link_text com o 'Clique aqui'