### PR TITLE
Corrige #136.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,10 +6,15 @@ Alterações
 
 .. Warning::
     A estrutura de dados do tile "Destaque" foi alterada. Se você tiver algum
-    tile desse tipo em sua capa, ele não será renderizada até que o upgradeStep
+    tile desse tipo em sua capa, ele não será renderizado até que o upgradeStep
     de brasil.gov.tiles seja executado. Execute também os upgradeSteps de
     collective.cover uma vez que collective.cover não é mais pinado no
-    buildout.cfg.
+    buildout.cfg e as versões mais novas no momento desse release de
+    brasil.gov.tiles contém upgrades.
+
+- Corrige capa quebrada quando uma notícia (collective.nitf) sem imagem é
+  adicionada num MediaCarouselTile. (closes `#136`).
+  [idgserpro]
 
 - Corrige teste quando se utiliza collective.cover 1.0a11 (closes `#132`).
   [idgserpro]
@@ -267,3 +272,4 @@ Alterações
 .. _`#120`: https://github.com/plonegovbr/brasil.gov.tiles/issues/120
 .. _`#123`: https://github.com/plonegovbr/brasil.gov.tiles/issues/123
 .. _`#132`: https://github.com/plonegovbr/brasil.gov.tiles/issues/132
+.. _`#136`: https://github.com/plonegovbr/brasil.gov.tiles/issues/136

--- a/src/brasil/gov/tiles/tests/test_carousel.py
+++ b/src/brasil/gov/tiles/tests/test_carousel.py
@@ -40,7 +40,7 @@ class CarouselTileTestCase(TestTileMixin, unittest.TestCase):
         self.tile.populate_with_object(obj)
 
         rendered = self.tile()
-        msg = u'Galleria.loadTheme("++resource++collective.cover/galleria-theme/galleria.cover_theme.js");'  # NOQA
+        msg = u'Galleria.loadTheme("++resource++collective.cover/galleria-theme/galleria.cover_theme.js");'
         self.assertIn(msg, rendered)
 
     def test_accepted_content_types(self):

--- a/src/brasil/gov/tiles/tests/test_mediacarousel_tile.robot
+++ b/src/brasil/gov/tiles/tests/test_mediacarousel_tile.robot
@@ -10,6 +10,10 @@ Suite Teardown  Close all browsers
 
 ${mediacarousel_tile_location}  'mediacarousel'
 ${collection_selector}  .ui-draggable .contenttype-collection
+# This xpath selector is for the <a> father of <span>my-news-folder</span>
+${my_news_folder_selector}  //span[contains(text(),'my-news-folder')]/..
+${title_nitf_with_image}  my-nitf-with-image
+${title_nitf_without_image}  my-nitf-without-image
 ${tile_selector}  div.tile-container div.tile
 ${edit_link_selector}  a.edit-tile-link
 ${title_field_id}  mediacarousel-header
@@ -106,6 +110,33 @@ Test Mediacarousel Tile
     Input Text  id=${footer_field_id}  ${footer_other_sample}
     Click Button  Cancel
     Wait Until Page Contains  ${footer_sample}
+
+    # delete the tile
+    Edit Cover Layout
+    Delete Tile
+    Save Cover Layout
+
+    # add a mediacarousel tile to the layout
+    Edit Cover Layout
+    Wait until page contains  Export layout
+    Add Tile  ${mediacarousel_tile_location}
+    Save Cover Layout
+
+    # as tile is empty, we see default message
+    Compose Cover
+    Page Should Contain  Drag a folder or collection to populate the tile.
+
+    # drag&drop a folder with nitf content
+    Open Content Chooser
+    Click Link  link=Content tree
+    Drag And Drop  xpath=${my_news_folder_selector}  css=${tile_selector}
+    Wait Until Page Contains Element  css=div.mediacarousel.tile-content h2.mediacarousel-tile+div
+    Wait Until Page Contains  ${title_nitf_with_image}
+    Page Should Not Contain  ${title_nitf_without_image}
+
+    # move to the default view and check tile persisted
+    Click Link  link=View
+    Page Should Contain Element  css=div.mediacarousel.tile-content h2.mediacarousel-tile
 
     # delete the tile
     Edit Cover Layout

--- a/src/brasil/gov/tiles/tiles/basic.py
+++ b/src/brasil/gov/tiles/tiles/basic.py
@@ -133,7 +133,7 @@ class BasicTile(PersistentCoverTile):
             'uuid': IUUID(obj, None),  # XXX: can we get None here? see below
             'date': True,
             'subjects': True,
-            'image_description': safe_unicode(obj.Description()) or safe_unicode(obj.Title()),  # NOQA
+            'image_description': safe_unicode(obj.Description()) or safe_unicode(obj.Title()),
         }
 
         # TODO: if a Dexterity object does not have the IReferenceable

--- a/src/brasil/gov/tiles/tiles/list.py
+++ b/src/brasil/gov/tiles/tiles/list.py
@@ -168,7 +168,7 @@ class ListTile(PersistentCoverTile):
             field = {'title': obj.title}
             if name in conf:
                 field_conf = conf[name]
-                if ('visibility' in field_conf and field_conf['visibility'] == u'off'):  # NOQA
+                if ('visibility' in field_conf and field_conf['visibility'] == u'off'):
                     # If the field was configured to be invisible, then just
                     # ignore it
                     continue
@@ -216,7 +216,7 @@ class ListTile(PersistentCoverTile):
                 scaleconf = image_conf['imgsize']
                 if (scaleconf != '_original'):
                     # scale string is something like: 'mini 200:200'
-                    scale = scaleconf.split(' ')[0]  # we need the name only: 'mini'  # NOQA
+                    scale = scaleconf.split(' ')[0]  # we need the name only: 'mini'
                 else:
                     scale = None
                 scales = item.restrictedTraverse('@@images')

--- a/src/brasil/gov/tiles/tiles/mediacarousel.py
+++ b/src/brasil/gov/tiles/tiles/mediacarousel.py
@@ -123,7 +123,10 @@ class MediaCarouselTile(ListTile):
             url = obj.absolute_url() + '/@@images/image'
         elif portal_type == 'collective.nitf.content':
             scale = self.scale(obj)
-            url = scale.url
+            if scale is not None:
+                url = scale.url
+            else:
+                url = obj.absolute_url()
 
         return url
 


### PR DESCRIPTION
https://github.com/plonegovbr/brasil.gov.tiles/issues/136

Evita que dê erro no servidor caso o usuário cadastre um objeto do tipo
collective.nitf sem imagem no mediacarousel (Carrossel Multimídia).