### PR TITLE
Muda algumas pinagens desnecessárias.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -46,24 +46,14 @@ eggs =
 # requerida pelo plone.
 createcoverage = 1.4
 
-# use latest version of setuptools
-setuptools =
-
-# z3c.unconfigure
-z3c.unconfigure = 1.1
+# z3c.unconfigure, 1.1, pede zope.configuration >= 3.8.0 no setup.py.
 zope.configuration = 3.8.0
 
-# Products.PloneFormGen >= 1.8 requer Plone 5
-Products.PloneFormGen = < 1.8
-
-# XXX: Ao adicionar collective.cover[test] em setup.py (necessário para usar
-# o tzlocal em collective.cover.setup.py, usado em nossos testes já que passo a
-# herdar do Fixture de collective.cover em testing.py), recebemos o erro
-# cop, cv = _parse_constraint(constraint).group(1, 2)
-# AttributeError: 'NoneType' object has no attribute 'group'
-# e a solução para isso é usar uma versão mais nova do buildout. Ver
-# https://github.com/buildout/buildout/issues/99
-zc.buildout = >= 2.2.5
+# BBB:
+# Products.PloneFormGen >= 1.8 requer Plone 5.
+# collective.cover[test] também pina, mas o ciclo de vida do collective.cover
+# provavelmente ficará compatível com o Plone 5 antes de brasil.gov.tiles.
+Products.PloneFormGen = <1.8.0.alpha1
 
 # É necessário ter o precompile para gerar os '*.mo' para os testes. Os '*.mo'
 # só são gerados quando a instância sobe e para executar os testes a instância


### PR DESCRIPTION
Ao adicionar collective.cover[test] em setup.py (necessário para usar
o tzlocal em collective.cover.setup.py, usado em nossos testes já que passo a
herdar do Fixture de collective.cover em testing.py), ele instala o
Products.PloneFormGen. Como a pinagem em nosso buildout.cfg para o PloneFormGen
estava

    Products.PloneFormGen = < 1.8

dava o erro

    cop, cv = _parse_constraint(constraint).group(1, 2)
    AttributeError: 'NoneType' object has no attribute 'group'

E a solução para isso é ou usar uma versão mais nova do buildout, ou mudar a
pinagem ficando sem o espaço:

    Products.PloneFormGen = <1.8

Ver https://github.com/buildout/buildout/issues/99 para maiores
informações.