### PR TITLE
Correção na versão

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         # Após o commit 007adcde40d2031a15debd5122af8086a1db6fa6, necessito a
         # partir dessa versão pois alterei o caminho dos recursos estáticos no
         # overrides.zcml.
-        'collective.cover > 1.0a12',
+        'collective.cover >= 1.0a12',
         'collective.nitf',
         'collective.polls',
         'collective.prettydate',


### PR DESCRIPTION
Na url http://downloads.plone.org.br/release/1.1.4-pending/versions.cfg a versão pinada é "collective.cover = 1.0a12".

Erro após rodar o buildout:
"Error: The requirement ('collective.cover>1.0a12') is not allowed by your [versions] constraint (1.0a12)"