### PR TITLE
#144

### DIFF
--- a/src/brasil/gov/tiles/tiles/templates/header.pt
+++ b/src/brasil/gov/tiles/tiles/templates/header.pt
@@ -5,7 +5,7 @@
       i18n:domain="brasil.gov.tiles">
 <body>
 
-    <div class="outstanding-header">
+    <div class="outstanding-header tile-content">
     <tal:fields repeat="field view/get_configured_fields">
 
         <tal:link define="htmltag python:field.get('htmltag', 'h1')"


### PR DESCRIPTION
Correção do tile cabeçalho após a edição do título não carrega o texto alterado #144
