### PR TITLE
Update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,25 @@ sudo: false
 cache:
   directories:
   - eggs
+  - parts/node
 env: PLONE_VERSION=4.3
+matrix:
+  fast_finish: true
 install:
 - sed -i "s#test-4.3#test-$PLONE_VERSION#" buildout.cfg
 - python bootstrap.py
 - bin/buildout annotate
 - bin/buildout
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - firefox -v
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
+- firefox -v
 script:
 - bin/code-analysis
 - bin/test
 after_success:
 - bin/createcoverage
-- pip install -q coveralls
+- pip install coveralls
 - coveralls
 notifications:
   irc: irc.freenode.org#plonegovbr

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,6 +2,7 @@
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
     https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
+    https://raw.githubusercontent.com/plonegovbr/portalpadrao.release/master/1.1.4-pending/versions.cfg
     https://raw.githubusercontent.com/plone/plone.app.robotframework/master/versions.cfg
     https://raw.githubusercontent.com/collective/collective.cover/master/versions-4.3.x.cfg
 
@@ -17,15 +18,12 @@ parts +=
     precompile
 
 [code-analysis]
+recipe = plone.recipe.codeanalysis[recommended]
 directory = ${buildout:directory}/src/brasil/gov/tiles
-pre-commit-hook = True
-flake8-ignore = E501
 clean-lines = True
-deprecated-aliases = True
-imports = True
-prefer-single-quotes = True
+flake8-ignore = B901,D001,E501,I001,P001,P002,Q000,T000,S001
+pre-commit-hook = True
 return-status-codes = True
-utf8-header = True
 
 [i18ndude]
 recipe = zc.recipe.egg
@@ -41,19 +39,15 @@ eggs =
     ${test:eggs}
     plone.app.robotframework[ride,reload]
 
+[test]
+environment = testenv
+
+[testenv]
+PLONE_CSRF_DISABLED = true
+
 [versions]
-# createcoverage 1.4.1 requer coverage>=3.7, dando conflito com a versão
-# requerida pelo plone.
-createcoverage = 1.4
-
-# z3c.unconfigure, 1.1, pede zope.configuration >= 3.8.0 no setup.py.
-zope.configuration = 3.8.0
-
-# BBB:
-# Products.PloneFormGen >= 1.8 requer Plone 5.
-# collective.cover[test] também pina, mas o ciclo de vida do collective.cover
-# provavelmente ficará compatível com o Plone 5 antes de brasil.gov.tiles.
-Products.PloneFormGen = <1.8.0.alpha1
+# use latest version of coverage
+coverage =
 
 # É necessário ter o precompile para gerar os '*.mo' para os testes. Os '*.mo'
 # só são gerados quando a instância sobe e para executar os testes a instância

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,10 @@ ignore =
     Makefile
     bootstrap.py
     *.cfg
+
+[isort]
+force_alphabetical_sort = True
+force_single_line = True
+line_length = 200
+lines_after_imports = 2
+not_skip = __init__.py


### PR DESCRIPTION
- download new versions of non-pinned packages if available
- use 1.1.4-pending version pinning
- update code analysis configuration
- use latest version of coverage