### PR TITLE
Adiciona plone4.csrffixes como dependência

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Alterações
 1.1rc2 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Adiciona plone4.csrffixes como dependência.
+  [idgserpro]
+
 - Adiciona plone.api como dependência.
   [idgserpro]
 
@@ -37,6 +40,7 @@ Alterações
 
 - Corrige teste quando se utiliza collective.cover 1.0a11 (closes `#132`).
   [idgserpro]
+
 
 1.0.7 (2015-09-03)
 ^^^^^^^^^^^^^^^^^^

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -41,12 +41,6 @@ eggs =
     ${test:eggs}
     plone.app.robotframework[ride,reload]
 
-[test]
-environment = testenv
-
-[testenv]
-PLONE_CSRF_DISABLED = true
-
 [versions]
 # use latest version of coverage
 coverage =

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'plone.namedfile',
         'plone.tiles',
         'plone.uuid',
+        'plone4.csrffixes',
         'Products.CMFCore',
         'Products.CMFPlone >=4.3',
         'Products.GenericSetup',

--- a/src/brasil/gov/tiles/configure.zcml
+++ b/src/brasil/gov/tiles/configure.zcml
@@ -14,6 +14,8 @@
     <include package="five.grok" />
     <grok:grok package="." />
 
+    <include package="plone4.csrffixes" />
+
     <!-- Profiles de Generic Setup -->
     <include file="profiles.zcml" />
 


### PR DESCRIPTION
Como estamos utilizando o plone.protect 3.x:

https://github.com/plonegovbr/portalpadrao.release/blob/2b5d7d11089ad4a6096b7cec248d46a80d9b2b9b/1.1.4/versions.cfg#L608

temos que utilizar o plone4.csrffixes:

https://github.com/plone/plone.protect#compatibility

Sem o plone4.csrffixes, ocorre erro no bin/instance, quando editamos uma tile.