### PR TITLE
Melhorar a estrutura de testes de dependências em futuros releases, evitando que muitos erros só apareçam quando é lançado o release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,16 @@ cache:
   directories:
   - eggs
   - parts/node
-env: PLONE_VERSION=4.3
+env:
+  matrix:
+    - MASTER=true
+    - PENDING_RELEASE=true
 matrix:
+  allow_failures:
+    - env: MASTER=true
   fast_finish: true
 install:
-- sed -i "s#test-4.3#test-$PLONE_VERSION#" buildout.cfg
+- test $MASTER && sed -ie '/https:\/\/raw\.githubusercontent\.com\/plonegovbr\/portal\.buildout\/master\/buildout\.d\/versions\.cfg/d' buildout.cfg || true
 - python bootstrap.py
 - bin/buildout annotate
 - bin/buildout

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ script:
 - bin/code-analysis
 - bin/test
 after_success:
-- bin/createcoverage
-- pip install coveralls
+- bin/createcoverage -t "--layer=!Acceptance"
+- pip install -q coveralls
 - coveralls
 notifications:
   irc: irc.freenode.org#plonegovbr

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,9 +2,9 @@
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
     https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
-    https://raw.githubusercontent.com/plonegovbr/portalpadrao.release/master/1.1.4/versions.cfg
     https://raw.githubusercontent.com/plone/plone.app.robotframework/master/versions.cfg
     https://raw.githubusercontent.com/collective/collective.cover/master/versions-4.3.x.cfg
+    https://raw.githubusercontent.com/plonegovbr/portal.buildout/master/buildout.d/versions.cfg
 
 package-name = brasil.gov.tiles
 package-extras = [test]


### PR DESCRIPTION
Pacotes plonegovbr deveriam ter mais de um job de testes : plonegovbr/portalpadrao.release#11