### PR TITLE
Remove pinagem flake8-coding.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -50,8 +50,6 @@ coverage =
 # baixado de novo: o fato dele estar no src não impede o download
 # dele de novo como um egg se ele estiver pinado no extends.
 brasil.gov.tiles =
-# XXX: https://github.com/plonegovbr/portalpadrao.release/blob/master/1.1.4/versions.cfg#L533
-flake8-coding = 1.2.2
 
 # É necessário ter o precompile para gerar os '*.mo' para os testes. Os '*.mo'
 # só são gerados quando a instância sobe e para executar os testes a instância


### PR DESCRIPTION
Como esse pacote passa a usar as versões definidas em 

    https://raw.githubusercontent.com/plonegovbr/portal.buildout/master/buildout.d/versions.cfg

Não preciso mais da pinagem de flake8-coding uma vez que passo a usar as versões pinadas do versions.cfg do próximo release.