### PR TITLE
(Patch) exclusão/reordenação Banner Rotativo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Alterações
 1.2rc1 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
+- Corrige exclusão e reordenação de itens de um Banner Rotativo com o uso de um
+  patch. A correção definitiva deverá usar o tipo lista do collective.cover
+  em outra versão.
+  (partially closes `#145`)
+
 - Segue o padrão do collective.cover de usar uuid ao invés de uid. (partially closes `#145`)
   [rodfersou, idgserpro]
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         # partir dessa versão pois alterei o caminho dos recursos estáticos no
         # overrides.zcml.
         'collective.cover > 1.0a12',
+        'collective.monkeypatcher',
         'collective.nitf',
         'collective.polls',
         'collective.prettydate',

--- a/src/brasil/gov/tiles/configure.zcml
+++ b/src/brasil/gov/tiles/configure.zcml
@@ -3,6 +3,7 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:grok="http://namespaces.zope.org/grok"
     xmlns:i18n="http://namespaces.zope.org/i18n"
+    xmlns:monkey="http://namespaces.plone.org/monkey"
     xmlns:plone="http://namespaces.plone.org/plone"
     i18n_domain="brasil.gov.tiles">
 
@@ -39,5 +40,18 @@
       name="brasil.gov.tiles"
       provides="Products.CMFPlone.interfaces.INonInstallable"
       />
+
+  <!--FIXME: Correção de Banner Rotativo enquanto o tipo lista de brasil.gov.tiles-->
+  <!--não é substituído pelo de collective.cover.-->
+  <!--Exclusão-->
+  <monkey:patch
+    preconditions="collective.cover==1.1b1"
+    description="Testa interface lista do brasil.gov.tiles na hora de remover itens ao invés interface da lista de collective.cover."
+    class="collective.cover.browser.cover.RemoveItemFromListTile"
+    original="render"
+    replacement=".patches_banner_rotativo.render"
+    preserveOriginal="true"
+    />
+  <!--Exclusão-->
 
 </configure>

--- a/src/brasil/gov/tiles/patches_banner_rotativo.py
+++ b/src/brasil/gov/tiles/patches_banner_rotativo.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""
+Preciso de um arquivo separado para esse patch.
+
+Isso ocorre porque se eu coloco para importar
+
+    from brasil.gov.tiles.tiles.list import IListTile as brasilIListTile
+
+em patches.py, dá erro de dependência circular porque brasilIListTile importa
+o message factory padrão de brasil.gov.tiles, mas ele é definido no __init__.py
+do pacote que chama a importação dando o erro de import:
+
+  File "brasil/gov/tiles/__init__.py", line 2, in <module>
+    from brasil.gov.tiles import patches
+  File "brasil/gov/tiles/patches.py", line 3, in <module>
+    from brasil.gov.tiles.tiles.list import IListTile
+  File "brasil/gov/tiles/tiles/list.py", line 2, in <module>
+    from brasil.gov.tiles import _ as _
+zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "parts/instance/etc/site.zcml", line 12.2-12.39
+    ZopeXMLConfigurationError: File "Products/CMFPlone/meta.zcml", line 42.4-46.10
+    ImportError: cannot import name _
+
+Como esse patch é temporário, na hora da remoção esse arquivo pode ser removido
+por completo.
+
+"""
+
+from brasil.gov.tiles.tiles.list import IListTile as brasilIListTile
+from collective.cover.tiles.list import IListTile
+from zExceptions import BadRequest
+
+
+def render_banner_rotativo(self):
+    """
+    Customizado de
+
+    https://github.com/collective/collective.cover/blob/1.1b1/src/collective/cover/browser/cover.py#L327
+    """
+    tile_type = self.request.form.get('tile-type')
+    tile_id = self.request.form.get('tile-id')
+    uuid = self.request.form.get('uuid')
+    if tile_type and tile_id and uuid:
+        tile = self.context.restrictedTraverse('{0}/{1}'.format(tile_type, tile_id))
+        # Essa chamada foi a única customização do método.
+        if IListTile.providedBy(tile) or brasilIListTile.providedBy(tile):
+            tile.remove_item(uuid)
+            # reinstantiate the tile to update its content on AJAX calls
+            tile = self.context.restrictedTraverse('{0}/{1}'.format(tile_type, tile_id))
+            return tile()
+    else:
+        raise BadRequest('Invalid parameters')
+
+
+def render(self):
+    """Preocupe-se apenas com o banner_rotativo."""
+    tile_type = self.request.form.get('tile-type')
+    if tile_type == 'banner_rotativo':
+        render_banner_rotativo(self)
+    else:
+        self._old_render(self)

--- a/src/brasil/gov/tiles/tiles/templates/banner_rotativo.pt
+++ b/src/brasil/gov/tiles/tiles/templates/banner_rotativo.pt
@@ -4,8 +4,14 @@
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       i18n:domain="brasil.gov.tiles">
     <head>
+        <tal:comment tal:replace="nothing">
+            FIXME: Atribuo, no fim da chamada de javascript, o commit responsável por alteração no mesmo. Isso é necessário enquanto
+            https://github.com/plonegovbr/brasil.gov.tiles/issues/175 não é resolvido para evitar problemas com cache.
+            Toda alteração feita no javascript necessitará de uma mudança com uma string única enquanto o relato de colocar tudo
+            em jsregistry.xml não for resolvido.
+        </tal:comment>
         <script type="text/javascript"
-                tal:attributes="src string:${context/@@plone_portal_state/portal_url}/++resource++brasil.gov.tiles/banner_rotativo.js">
+                tal:attributes="src string:${context/@@plone_portal_state/portal_url}/++resource++brasil.gov.tiles/banner_rotativo.js?v=74d45e30e956d274bdddcb12f255fd78417f484a">
         </script>
     </head>
     <body>


### PR DESCRIPTION
Corrige exclusão e reordenação de itens de um Banner Rotativo com o uso de um
patch. A correção definitiva deverá usar o tipo lista do collective.cover
em outra versão.

Após

    https://github.com/collective/collective.cover/pull/722

ter sido mesclado, a correção definitiva em

    https://github.com/plonegovbr/brasil.gov.tiles/pull/173

vai precisar ser repensada e, como ainda não há prazo definido para
isso, para corrigir o erro https://github.com/plonegovbr/brasil.gov.tiles/issues/145
nem que seja temporariamente será feito como está nesse commit.