### PR TITLE
Adapta para funcionar >= collective.cover 1.6b1.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,13 @@ Alterações
 1.2rc2 (unreleased)
 ^^^^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+.. Warning::
+    A versão necessária do collective.cover para ser utilizada com esse pacote
+    passa a ser >= 1.3b1.
+
+- Adapta brasil.gov.tiles para funcionar na versão mais atual de collective.cover,
+  1.6b1.
+  [idgserpro]
 
 
 1.2rc1 (2017-06-23)

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        # Após o commit 007adcde40d2031a15debd5122af8086a1db6fa6, necessito a
-        # partir dessa versão pois alterei o caminho dos recursos estáticos no
-        # overrides.zcml.
-        'collective.cover > 1.0a12',
+        # O patch adicionado em configure.zcml espera uma classe presente em
+        # collective.cover.browser.compose.RemoveItemFromListTile, só
+        # só disponível a partir dessa versão.
+        'collective.cover >= 1.3b1',
         'collective.monkeypatcher',
         'collective.nitf',
         'collective.polls',
@@ -56,7 +56,7 @@ setup(
         'plone.app.blocks',
         'plone.app.dexterity [grok, relations]',
         # BBB: Com a atualização do collective.cover para 1.5b1 esse pacote
-        # foi removido mas ainda mantém utilities no ZODB para portais em produção. Quando 
+        # foi removido mas ainda mantém utilities no ZODB para portais em produção. Quando
         # https://github.com/plonegovbr/brasil.gov.portal/issues/348#issuecomment-309847978
         # for atendido pode-se estudar sua remoção.
         'plone.app.drafts',

--- a/src/brasil/gov/tiles/configure.zcml
+++ b/src/brasil/gov/tiles/configure.zcml
@@ -44,10 +44,11 @@
   <!--FIXME: Correção de Banner Rotativo enquanto o tipo lista de brasil.gov.tiles-->
   <!--não é substituído pelo de collective.cover.-->
   <!--Exclusão-->
+  <include package="collective.monkeypatcher" file="meta.zcml"/>
   <monkey:patch
     preconditions="collective.cover==1.1b1"
     description="Testa interface lista do brasil.gov.tiles na hora de remover itens ao invés interface da lista de collective.cover."
-    class="collective.cover.browser.cover.RemoveItemFromListTile"
+    class="collective.cover.browser.compose.RemoveItemFromListTile"
     original="render"
     replacement=".patches_banner_rotativo.render"
     preserveOriginal="true"

--- a/src/brasil/gov/tiles/tests/test_basic.py
+++ b/src/brasil/gov/tiles/tests/test_basic.py
@@ -88,7 +88,7 @@ class BasicTileTestCase(BaseIntegrationTestCase):
         contexto, a template, ao receber None, popula o html com
         tile-generic.png.
 
-        Com a nova versão de collective.cover 1.0a13, ele já retorna /img/tile
+        Com a nova versão de collective.cover, > 1.0a12, ele já retorna /img/tile
         na template ao invés de só /tile e esse teste verifica isso, mas
         renderizando o html da view.
 
@@ -109,8 +109,10 @@ class BasicTileTestCase(BaseIntegrationTestCase):
                 container=self.portal,
                 template_layout='Layout A'
             )
-        view = self.portal['my-cover'].restrictedTraverse('@@tile_list')
-        view.update()
+            # A partir da versão 1.3b1 de collective.cover, com a remoção do
+            # grok, essa view que tinha a permissão de 'zope2.View' passa a ter
+            # 'collective.cover.CanEditLayout'.
+            view = self.portal['my-cover'].restrictedTraverse('@@tile_list')
         html = view()
         prefix_icon = '++resource++collective.cover/img/tile-'
         total_in_rendered_view = html.count(prefix_icon)

--- a/src/brasil/gov/tiles/tests/test_destaque_tile.py
+++ b/src/brasil/gov/tiles/tests/test_destaque_tile.py
@@ -58,7 +58,7 @@ class DestaqueTileTestCase(TestTileMixin, unittest.TestCase):
 
         # next, we replace the destaque of objects with a different one
         obj3 = self.portal['my-news-item']
-        tile.replace_with_objects([api.content.get_uuid(obj3)])
+        tile.replace_with_uuids([api.content.get_uuid(obj3)])
         # tile's data attributed is cached so we should re-instantiate the tile
         tile = getMultiAdapter(
             (self.cover, self.request),

--- a/src/brasil/gov/tiles/tiles/destaque.py
+++ b/src/brasil/gov/tiles/tiles/destaque.py
@@ -55,11 +55,41 @@ class DestaqueTile(ListTile):
     is_droppable = True
     is_editable = False
     limit = 2
+    short_name = _(u'A highlight tile', default=u'A highlight tile')
 
+    # FIXME: Até a versão 1.4b1 de collective.cover, o funcionamento da lista
+    # do collective.cover e do brasil.gov.tiles, apesar de uma diferença ou outra
+    # bem pontual, eram bem similares. A partir da 1.5b1, devido ao PR
+    # https://github.com/collective/collective.cover/pull/714,
+    # a forma de tratar diretórios e coleções mudou de forma drástica nos tiles
+    # mas ainda não estamos preparados para essa mudança (pois os demais tiles
+    # ainda herdam do ListTile de brasil.gov.tiles).
+    # Como ainda iremos atender ao PR
+    # https://github.com/plonegovbr/brasil.gov.tiles/pull/173 que irá resolver
+    # isso de forma definitiva, iremos redefinir os métodos que funcionavam ok
+    # na 1.1b1 mas que foram alterados no 1.5b1 para manter esse tile com o
+    # mesmo comportamento dos demais em brasil.gov.tiles.
+    def populate_with_object(self, obj):
+        """ Add an object to the list of items
+
+        :param obj: [required] The object to be added
+        :type obj: Content object
+        """
+        super(ListTile, self).populate_with_object(obj)  # check permission
+        uuids = ICoverUIDsProvider(obj).getUIDs()
+        if uuids:
+            self.populate_with_uuids(uuids)
+
+    # FIXME: Com a atualização para 1.1b1 e 1.6b1, esse método pode ser removido.
+    # Avaliar e testar durante o PR
+    # https://github.com/plonegovbr/brasil.gov.tiles/pull/173
     # XXX: are we using this function somewhere? remove?
     def get_uuid(self, obj):
         return api.content.get_uuid(obj)
 
+    # FIXME: Com a atualização para 1.1b1 e 1.6b1, esse método pode ser removido.
+    # Avaliar e testar durante o PR
+    # https://github.com/plonegovbr/brasil.gov.tiles/pull/173
     @view.memoize
     def accepted_ct(self):
         """


### PR DESCRIPTION
Passa a pedir collective.cover >= 1.3b1.

@hvelarde se possível revisar e gerar um release na sequência, precisamos dessa versão para poder lançar um release do IDGB que utiliza o collective.cover 1.6b1.