### PR TITLE
Avoid ConstraintNotSatisfied error while upgrading from 1.x

### DIFF
--- a/src/brasil/gov/tiles/tests/test_upgrades.py
+++ b/src/brasil/gov/tiles/tests/test_upgrades.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
+from brasil.gov.tiles import utils
 from brasil.gov.tiles.testing import INTEGRATION_TESTING
-from collective.cover.controlpanel import ICoverSettings
 from plone import api
 
 import unittest
@@ -42,7 +42,7 @@ class UpgradeTo4100TestCase(BaseUpgradeTestCase):
 
     def test_registered_steps(self):
         steps = len(self.setup.listUpgrades(self.profile_id)[0])
-        self.assertEqual(steps, 9)
+        self.assertEqual(steps, 10)
 
     def test_update_resources_references(self):
         # address also an issue with Setup permission
@@ -100,25 +100,15 @@ class UpgradeTo4100TestCase(BaseUpgradeTestCase):
         self.assertNotIn('++resource++brasil.gov.tiles/jquery.jplayer.min.js', js_ids)
         self.assertNotIn('++resource++brasil.gov.tiles/swiper.min.js', js_ids)
 
-    @staticmethod
-    def get_registered_tiles():
-        return api.portal.get_registry_record(name='plone.app.tiles')
+    def test_remove_deprecated_tiles(self):
+        title = u'Remove deprecated tiles'
+        step = self._get_upgrade_step_by_title(title)
+        self.assertIsNotNone(step)
 
-    @staticmethod
-    def set_registered_tiles(value):
-        api.portal.set_registry_record(name='plone.app.tiles', value=value)
+        # run the upgrade step to validate the update
+        self._do_upgrade(step)
 
-    @staticmethod
-    def get_available_tiles():
-        record = dict(interface=ICoverSettings, name='available_tiles')
-        return api.portal.get_registry_record(**record)
-
-    def unregister_tile(self, tile):
-        registered_tiles = self.get_registered_tiles()
-        registered_tiles.remove(tile)
-        self.set_registered_tiles(value=registered_tiles)
-        self.assertNotIn(tile, self.get_registered_tiles())
-        self.assertNotIn(tile, self.get_available_tiles())
+        # no easy way to test tile removal: raises ConstraintNotSatisfied
 
     def test_add_potd_tile(self):
         title = u'Add POTD tile'
@@ -126,13 +116,13 @@ class UpgradeTo4100TestCase(BaseUpgradeTestCase):
         self.assertIsNotNone(step)
 
         tile = u'brasil.gov.tiles.potd'
-        self.unregister_tile(tile)
+        utils.disable_tile(tile)
 
         # run the upgrade step to validate the update
         self._do_upgrade(step)
 
-        self.assertIn(tile, self.get_registered_tiles())
-        self.assertIn(tile, self.get_available_tiles())
+        self.assertIn(tile, utils.get_registered_tiles())
+        self.assertIn(tile, utils.get_available_tiles())
 
     def test_add_quote_tile(self):
         title = u'Add Quote tile'
@@ -140,13 +130,13 @@ class UpgradeTo4100TestCase(BaseUpgradeTestCase):
         self.assertIsNotNone(step)
 
         tile = u'brasil.gov.tiles.quote'
-        self.unregister_tile(tile)
+        utils.disable_tile(tile)
 
         # run the upgrade step to validate the update
         self._do_upgrade(step)
 
-        self.assertIn(tile, self.get_registered_tiles())
-        self.assertIn(tile, self.get_available_tiles())
+        self.assertIn(tile, utils.get_registered_tiles())
+        self.assertIn(tile, utils.get_available_tiles())
 
     def test_add_photogallery_tile(self):
         title = u'Add Photo Gallery tile'
@@ -154,13 +144,13 @@ class UpgradeTo4100TestCase(BaseUpgradeTestCase):
         self.assertIsNotNone(step)
 
         tile = u'brasil.gov.tiles.photogallery'
-        self.unregister_tile(tile)
+        utils.disable_tile(tile)
 
         # run the upgrade step to validate the update
         self._do_upgrade(step)
 
-        self.assertIn(tile, self.get_registered_tiles())
-        self.assertIn(tile, self.get_available_tiles())
+        self.assertIn(tile, utils.get_registered_tiles())
+        self.assertIn(tile, utils.get_available_tiles())
 
     def test_add_navigation_tile(self):
         title = u'Add Navigation tile'
@@ -168,13 +158,13 @@ class UpgradeTo4100TestCase(BaseUpgradeTestCase):
         self.assertIsNotNone(step)
 
         tile = u'brasil.gov.tiles.navigation'
-        self.unregister_tile(tile)
+        utils.disable_tile(tile)
 
         # run the upgrade step to validate the update
         self._do_upgrade(step)
 
-        self.assertIn(tile, self.get_registered_tiles())
-        self.assertIn(tile, self.get_available_tiles())
+        self.assertIn(tile, utils.get_registered_tiles())
+        self.assertIn(tile, utils.get_available_tiles())
 
     def test_replace_nitf_tile(self):
         title = u'Replace NITF tile'
@@ -182,7 +172,7 @@ class UpgradeTo4100TestCase(BaseUpgradeTestCase):
         self.assertIsNotNone(step)
 
         tile = u'collective.nitf'
-        self.unregister_tile(tile)
+        utils.disable_tile(tile)
 
         # add object with an old tile on its layout
         with api.env.adopt_roles(['Manager']):
@@ -194,8 +184,8 @@ class UpgradeTo4100TestCase(BaseUpgradeTestCase):
         # run the upgrade step to validate the update
         self._do_upgrade(step)
 
-        self.assertIn(tile, self.get_registered_tiles())
-        self.assertIn(tile, self.get_available_tiles())
+        self.assertIn(tile, utils.get_registered_tiles())
+        self.assertIn(tile, utils.get_available_tiles())
 
         expected = '[{"type": "row", "children": [{"id": "group1", "type": "group", "column-size": 6, "roles": ["Manager"], "children": [{"tile-type": "collective.cover.basic", "type": "tile", "id": "4ebc5e6678044918b76280ec0204041a"}]}, {"type": "group", "column-size": 6, "roles": ["Manager"], "children": [{"tile-type": "collective.nitf", "type": "tile", "id": "7d68fd4cf0e34073aea99568f1e8eef6"}]}]}]'  # noqa: E501
         import json

--- a/src/brasil/gov/tiles/upgrades/__init__.py
+++ b/src/brasil/gov/tiles/upgrades/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding:utf-8 -*-
 from brasil.gov.tiles.logger import logger
-from collective.cover.controlpanel import ICoverSettings
 from plone import api
 
 
@@ -20,19 +19,9 @@ def cook_javascript_resources(context):  # pragma: no cover
 
 def add_tile(tile):
     """Register a tile and make it available."""
-    name = 'plone.app.tiles'
-    registered_tiles = api.portal.get_registry_record(name=name)
-    if tile not in registered_tiles:
-        registered_tiles.append(tile)
-        api.portal.set_registry_record(name=name, value=registered_tiles)
-        logger.info('{0} tile registered'.format(tile))
-
-    record = dict(interface=ICoverSettings, name='available_tiles')
-    available_tiles = api.portal.get_registry_record(**record)
-    if tile not in available_tiles:
-        available_tiles.append(tile)
-        api.portal.set_registry_record(value=available_tiles, **record)
-        logger.info('{0} tile made available'.format(tile))
+    from brasil.gov.tiles.utils import enable_tile
+    enable_tile(tile)
+    logger.info('{0} tile added'.format(tile))
 
 
 def get_valid_objects(**kw):
@@ -57,10 +46,11 @@ def replace_tile(layout, old, new):
     """Replace tile type on a layout."""
     new_layout = []
     for e in layout:
-        if 'tile-type' in e and e['tile-type'] == old:
+        if e.get('tile-type') == old:
             e['tile-type'] = new
         if e['type'] in ('row', 'group'):
-            e['children'] = replace_tile(e['children'], old, new)
+            if 'children' in e:
+                e['children'] = replace_tile(e['children'], old, new)
         new_layout.append(e)
     return new_layout
 

--- a/src/brasil/gov/tiles/upgrades/v4100/__init__.py
+++ b/src/brasil/gov/tiles/upgrades/v4100/__init__.py
@@ -37,6 +37,16 @@ def update_static_resources(setup_tool):
     logger.info('JavaScript resources were updated')
 
 
+DEPRECATED_TILES = [u'nitf']
+
+
+def remove_deprecated_tiles(setup_tool):
+    """Remove deprecated tiles."""
+    from brasil.gov.tiles.utils import disable_tile
+    for tile in DEPRECATED_TILES:
+        disable_tile(tile)
+
+
 def add_quote_tile(setup_tool):
     """Add Quote tile."""
     add_tile(u'brasil.gov.tiles.quote')

--- a/src/brasil/gov/tiles/upgrades/v4100/configure.zcml
+++ b/src/brasil/gov/tiles/upgrades/v4100/configure.zcml
@@ -13,6 +13,11 @@
         />
 
     <genericsetup:upgradeStep
+        title="Remove deprecated tiles"
+        handler=".remove_deprecated_tiles"
+        />
+
+    <genericsetup:upgradeStep
         title="Add POTD tile"
         handler=".add_potd_tile"
         />

--- a/src/brasil/gov/tiles/utils.py
+++ b/src/brasil/gov/tiles/utils.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from collective.cover.controlpanel import ICoverSettings
+from plone import api
+
+
+# TODO: remove all code related to tile registration as registry
+#       record is deprecated (we are using plone.app.tiles > 3.0.0)
+#       see: https://github.com/plone/plone.app.tiles/pull/14
+def get_registered_tiles():
+    """Return a list of registered tiles."""
+    return api.portal.get_registry_record(name='plone.app.tiles')
+
+
+def set_registered_tiles(value):
+    """Set a list of registered tiles."""
+    api.portal.set_registry_record(value=value, name='plone.app.tiles')
+
+
+def get_available_tiles():
+    """Return a list of available tiles."""
+    record = dict(interface=ICoverSettings, name='available_tiles')
+    return api.portal.get_registry_record(**record)
+
+
+def set_available_tiles(value):
+    """Set a list of available tiles."""
+    record = dict(interface=ICoverSettings, name='available_tiles')
+    api.portal.set_registry_record(value=value, **record)
+
+
+def enable_tile(tile):
+    """Register tile and enable it."""
+    registered_tiles = get_registered_tiles()
+    if tile not in registered_tiles:
+        registered_tiles.append(tile)
+        set_registered_tiles(value=registered_tiles)
+        assert tile in get_registered_tiles()  # nosec
+    available_tiles = get_available_tiles()
+    if tile not in available_tiles:
+        available_tiles.append(tile)
+        set_available_tiles(value=available_tiles)
+        assert tile in get_available_tiles()  # nosec
+
+
+def disable_tile(tile):
+    """Unregister tile and disable it."""
+    registered_tiles = get_registered_tiles()
+    if tile in registered_tiles:
+        registered_tiles.remove(tile)
+        set_registered_tiles(value=registered_tiles)
+        assert tile not in get_registered_tiles()  # nosec
+    available_tiles = get_available_tiles()
+    if tile in available_tiles:
+        available_tiles.remove(tile)
+        set_available_tiles(value=available_tiles)
+        assert tile not in get_available_tiles()  # nosec


### PR DESCRIPTION
Refactor tile registration and fix upgrade step to avoid KeyError.

I have tested an upgrade from 1.5.2 to 2.0 master branch using this and it was successful as you can see in the image:

![selection_023](https://user-images.githubusercontent.com/341393/44524379-a86ef180-a6b3-11e8-96c0-40ae42630ea4.png)
